### PR TITLE
By default keep replaces chain root, but allow opt-in to existing behavior

### DIFF
--- a/pkg/filter/config/v1alpha1/channel.go
+++ b/pkg/filter/config/v1alpha1/channel.go
@@ -169,7 +169,7 @@ func newChannel(ch declcfg.Channel, log *logrus.Entry) (*channel, error) {
 //     of version range matches at or below them, we will use the bundle lowest in the replaces chain.
 //   - The tail will be the first bundle in the replaces chain whose version range match count is 0. The tail is not
 //     included in the new chain.
-func (c *channel) filterByVersionRange(versionRange *mmsemver.Constraints, versionMap map[string]*mmsemver.Version) sets.Set[string] {
+func (c *channel) filterByVersionRange(versionRange *mmsemver.Constraints, versionMap map[string]*mmsemver.Version, minimizeSelection bool) sets.Set[string] {
 	keepEntries := sets.New[string]()
 
 	for cur := c.head; cur != nil; cur = cur.Replaces {
@@ -189,10 +189,13 @@ func (c *channel) filterByVersionRange(versionRange *mmsemver.Constraints, versi
 	//   count of unvisited tail nodes in the version range)
 	// - tail (highest node on the replaces chain that has 0 unvisited tail
 	//   nodes in the version range)
-	var head, tail *channelEntry
+	var (
+		head = c.head
+		tail *channelEntry
+	)
 	for cur := c.head; cur != nil; cur = cur.Replaces {
 		count := counts[cur.Name]
-		if count >= maxCount {
+		if minimizeSelection && count >= maxCount {
 			head = cur
 			maxCount = count
 		}
@@ -204,11 +207,15 @@ func (c *channel) filterByVersionRange(versionRange *mmsemver.Constraints, versi
 
 	// We how have head and tail, let's traverse head to tail and build a list of bundles to keep,
 	// emitting a warning if anything in the replaces chain is not in the version range.
+	keepReason := "is required to ensure inclusion of all bundles in the range"
+	if !minimizeSelection {
+		keepReason = "is included to preserve replaces chain from head"
+	}
 	for cur := head; cur != tail; cur = cur.Replaces {
 		if cur.Version == nil {
-			c.log.Warnf("including bundle %q: it is unversioned but is required to ensure inclusion of all bundles in the range", cur.Name)
+			c.log.Warnf("including bundle %q: it is unversioned but %s", cur.Name, keepReason)
 		} else if !versionRange.Check(cur.Version) {
-			c.log.Warnf("including bundle %q with version %q: it falls outside the specified range of %q but is required to ensure inclusion of all bundles in the range", cur.Name, cur.Version, versionRange)
+			c.log.Warnf("including bundle %q with version %q: it falls outside the specified range of %q but %s", cur.Name, cur.Version, versionRange, keepReason)
 		}
 		keepEntries.Insert(cur.Name)
 		for _, skip := range cur.Skips.UnsortedList() {

--- a/pkg/filter/config/v1alpha1/config.go
+++ b/pkg/filter/config/v1alpha1/config.go
@@ -41,6 +41,12 @@ type Channel struct {
 	// VersionRange is a semver range to filter the versions of the channel.
 	// If not set, all versions will be included.
 	VersionRange string `json:"versionRange,omitempty"`
+
+	// MinimizeSelection allows channel filtering to remove bundles at the
+	// root of the replaces chain. Using this option minimizes the selection
+	// but can cause metadata that sometimes exists only on the channel head
+	// to be removed.
+	MinimizeSelection bool `json:"minimizeSelection,omitempty"`
 }
 
 func LoadFilterConfiguration(r io.Reader) (*FilterConfiguration, error) {

--- a/pkg/filter/config/v1alpha1/filter.go
+++ b/pkg/filter/config/v1alpha1/filter.go
@@ -165,7 +165,7 @@ func (f *filter) FilterCatalog(_ context.Context, fbc *declcfg.DeclarativeConfig
 			if err != nil {
 				return nil, err
 			}
-			keepEntries = ch.filterByVersionRange(versionRange, versionMap[fbcCh.Package])
+			keepEntries = ch.filterByVersionRange(versionRange, versionMap[fbcCh.Package], chConfig.MinimizeSelection)
 			if len(keepEntries) == 0 {
 				return nil, fmt.Errorf("package %q channel %q has version range %q that results in an empty channel", fbcCh.Package, fbcCh.Name, chConfig.VersionRange)
 			}


### PR DESCRIPTION
Here's another potential solution for a way to correctly handle catalogs that contain metadata only in channel head bundles.

This solution ensures that the entries that are on the replaces chain and that include any of the bundles in their subtree that are in the replaces chain are included in the mirror set. 

This differs from the current behavior, which tries to minimize the mirror set. This minimization can choose a new bundle as the channel head, which has the negative outcome of not handling catalogs where metadata has been pruned from non-channel heads.

This PR acknowledges that there are use cases for minimizing the mirror set (UI metadata is not a strict requirement for OLM to function correctly), so a new option is added to the filter configuration called `MinimizeSelection` so that users that do not care about UI metadata can continue with the existing behavior.